### PR TITLE
Add package.json with ws dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "dewdle",
+  "version": "1.0.0",
+  "description": "An open source Telestrator",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/vreelb/Dewdle.git"
+  },
+  "author": "Ben Vreeland",
+  "license": "GPL-3.0",
+  "bugs": {
+    "url": "https://github.com/vreelb/Dewdle/issues"
+  },
+  "homepage": "https://github.com/vreelb/Dewdle#readme",
+  "dependencies": {
+    "ws": "^1.1.1"
+  }
+}


### PR DESCRIPTION
Having a package.json will allow all the dependencies to be installed very
easily simply by the user running "npm install" after obtaining the source
code. Also, when installing the dependencies this way, they get installed
locally (in the node_modules subdirectory in the source tree) so there is
no need to have root privilege to install them. Last but not least this could
be used to push releases to npm, so that the package can be installed on a
machine just using "npm install -g dewdle".